### PR TITLE
feat: one-step generate, add clear cli command

### DIFF
--- a/.github/workflows/generate-command.yml
+++ b/.github/workflows/generate-command.yml
@@ -109,7 +109,7 @@ jobs:
           GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
         run: |
           # Run morph generate with the provided source_name and default project_name
-          uv run morph generate ${{ github.event.inputs.source_name || 'klaviyo' }} --regenerate-all --auto-confirm
+          uv run morph build ${{ github.event.inputs.source_name || 'klaviyo' }} --with-generate
 
           # Store the exit code
           GENERATE_EXIT_CODE=$?

--- a/src/morph/ai/map.py
+++ b/src/morph/ai/map.py
@@ -185,9 +185,19 @@ def populate_missing_mappings(
             project_name=project_name,
         ),
     )
-    source_schema: models.SourceTableSummary = next(
-        (table for table in source_table_info if table.name == transform_parsed.source_stream_name),
-    )
+    try:
+        source_schema: models.SourceTableSummary = next(
+            (
+                table
+                for table in source_table_info
+                if table.name == transform_parsed.source_stream_name
+            ),
+        )
+    except StopIteration:
+        raise ValueError(
+            "Could not find a source table mapping that matches the name "
+            f"{transform_parsed.source_stream_name}"
+        ) from None
     if source_schema is None:
         raise ValueError(f"Source schema not found for {transform_parsed.source_stream_name}")
 

--- a/src/morph/ai/map.py
+++ b/src/morph/ai/map.py
@@ -177,6 +177,12 @@ def populate_missing_mappings(
         transform_name=transform_name,
     )
     transform_parsed = models.TransformFile.from_file(transform_file)
+    if transform_parsed.source_stream_name == constants.MISSING:
+        console.print(
+            f"Could not generate mappings for transform '{transform_parsed.transform_name}' "
+            "with missing source table.",
+            style="red",
+        )
     fields_to_populate: list[models.FieldMapping] = []
 
     source_table_info = models.SourceTableSummary.from_dbt_source_file(

--- a/src/morph/cli/main.py
+++ b/src/morph/cli/main.py
@@ -160,6 +160,13 @@ def visualize_dbml(
 @click.option("--no-transforms", is_flag=True)
 @click.option("--no-dbt-project", is_flag=True)
 @click.option("--no-lock-file", is_flag=True)
+@click.option(
+    "--with-generate",
+    is_flag=True,
+    help="Generate the AI mappings after project build",
+    type=bool,
+    default=False,
+)
 def build(
     source_name: str,
     project_name: str,
@@ -169,12 +176,14 @@ def build(
     no_transforms: bool | None = None,
     no_dbt_project: bool | None = None,
     no_lock_file: bool | None = None,
+    with_generate: bool | None = None,
 ) -> None:
     """Build auto-generated source and project artifacts."""
     no_airbyte_catalog = if_none(no_airbyte_catalog, False)
     no_transforms = if_none(no_transforms, False)
     no_dbt_project = if_none(no_dbt_project, False)
     no_lock_file = if_none(no_lock_file, False)
+    with_generate = if_none(with_generate, False)
 
     # Validate input arguments
     if not source_name or not project_name:
@@ -209,6 +218,16 @@ def build(
         console.print(f"Generating dbt project for {source_name}...")
         build_dbt_project(source_name, project_name)
         console.print(f"Generated dbt project for {source_name}")
+
+    if with_generate:
+        _generate(
+            source_name=source_name,
+            project_name=project_name,
+            auto_confirm=True,
+            regenerate_all=False,
+            include_skipped_tables=False,
+            no_build=False,
+        )
 
 
 @main.command()
@@ -315,6 +334,30 @@ def generate(
     no_build: bool = False,
 ) -> None:
     """Use AI to generate new transform code for a project."""
+    _generate(
+        source_name=source_name,
+        project_name=project_name,
+        auto_confirm=auto_confirm,
+        regenerate_all=regenerate_all,
+        include_skipped_tables=include_skipped_tables,
+        no_build=no_build,
+    )
+
+
+def _generate(
+    source_name: str,
+    project_name: str = DEFAULT_PROJECT_NAME,
+    *,
+    auto_confirm: bool | None = None,
+    regenerate_all: bool = False,
+    include_skipped_tables: bool = False,
+    no_build: bool = False,
+) -> None:
+    """Implements the generate CLI execution.
+
+    This separate method exists so that other CLI commands (like 'build') can
+    wrap the same execution.
+    """
     check_openai_api_key()
     requirements_dbt_source_file = resources.get_dbt_sources_requirements_path(
         source_name=source_name,

--- a/src/morph/cli/main.py
+++ b/src/morph/cli/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 import sys
 from pathlib import Path
 
@@ -479,6 +480,35 @@ def _generate(
         console.print("Rebuilding dbt project...", style="bold green")
         build_dbt_project(source_name, project_name)
         console.print("Build step completed successfully.", style="bold green")
+
+
+@main.command()
+@click.argument("source_name")
+@click.argument("project_name", default=DEFAULT_PROJECT_NAME)
+def clear(
+    source_name: str,
+    project_name: str = DEFAULT_PROJECT_NAME,
+) -> None:
+    paths_to_delete = [
+        resources.get_build_dir(
+            source_name,
+        ),
+        resources.get_transforms_dir(
+            source_name=source_name,
+            project_name=project_name,
+        ),
+        resources.get_generated_dbt_project_dir(
+            source_name=source_name,
+            project_name=project_name,
+        ),
+        resources.get_source_home_dir(
+            source_name=source_name,
+        ),
+    ]
+    for path_to_delete in paths_to_delete:
+        if path_to_delete.is_dir():
+            console.print(f"Deleting directory: {path_to_delete}", style="bold red")
+            shutil.rmtree(path_to_delete)
 
 
 if __name__ == "__main__":

--- a/src/morph/resources.py
+++ b/src/morph/resources.py
@@ -141,12 +141,19 @@ def get_catalog_root_dir() -> Path:
     return Path("catalog")
 
 
+def get_source_home_dir(
+    source_name: str,
+) -> Path:
+    """Assume we are running from the root of the morph repo."""
+    return get_catalog_root_dir() / source_name
+
+
 def get_generated_dbt_project_dir(
     source_name: str,
     project_name: str = DEFAULT_PROJECT_NAME,
 ) -> Path:
     """Get the path to the generated dbt project.yml file."""
-    return get_catalog_root_dir() / source_name / f"{project_name}-dbt-project"
+    return get_source_home_dir(source_name) / f"{project_name}-dbt-project"
 
 
 def get_generated_dbt_project_models_dir(
@@ -170,7 +177,7 @@ def get_generated_approved_mappings_doc_path(
 ) -> Path:
     """Get the path to the generated approved mappings README file."""
     _ = project_name  # Unused for now
-    return get_catalog_root_dir() / source_name / "README.md"
+    return get_source_home_dir(source_name) / "README.md"
 
 
 def get_generated_rejected_mappings_doc_path(
@@ -179,7 +186,7 @@ def get_generated_rejected_mappings_doc_path(
 ) -> Path:
     """Get the path to the generated rejected mappings README file."""
     _ = project_name  # Unused for now
-    return get_catalog_root_dir() / source_name / "rejected-mappings.md"
+    return get_source_home_dir(source_name) / "rejected-mappings.md"
 
 
 # Generated build artifacts (not user-facing):

--- a/src/transforms/hubspot/config.yml
+++ b/src/transforms/hubspot/config.yml
@@ -1,4 +1,4 @@
-project_id: hubspot.fivetran-interop
+project_id: hubspot.airbyte-interop
 source_name: hubspot
 # Target schema file snapshotted from: https://github.com/fivetran/dbt_hubspot_source/blob/main/models/src_hubspot.yml
 target_dbt_schema_url: https://raw.githubusercontent.com/fivetran/dbt_hubspot_source/refs/heads/main/models/src_hubspot.yml


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `--with-generate` option to the build command, allowing users to trigger AI-based generation of transform mappings as part of the build process.
  - Introduced a new `clear` command to remove generated build artifacts and related directories.

- **Bug Fixes**
  - Improved error messages when a source table mapping cannot be found, providing clearer feedback to users.

- **Refactor**
  - Unified AI mapping generation logic for easier maintenance and consistent behavior across commands.
  - Centralized resource path construction with a new helper function for better consistency.

- **Configuration**
  - Updated project identifier in Hubspot transform configuration from "hubspot.fivetran-interop" to "hubspot.airbyte-interop".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->